### PR TITLE
Migrate FA4 to Lucide

### DIFF
--- a/icon.tsx
+++ b/icon.tsx
@@ -1,0 +1,10 @@
+import { jsx, Static } from 'butterfloat'
+import { IconNode, createElement } from 'lucide'
+
+export interface IconProps {
+  icon: IconNode
+}
+
+export function Icon({ icon }: IconProps) {
+  return <Static element={createElement(icon)} />
+}

--- a/index.css
+++ b/index.css
@@ -1,5 +1,4 @@
 @import url('https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css');
-@import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css');
 
 .dashboard {
   display: grid;

--- a/main.js
+++ b/main.js
@@ -9641,6 +9641,12 @@ function Fragment(attributes, ...children) {
     childrenBindMode
   };
 }
+function Static({ element }) {
+  return {
+    type: "static",
+    element
+  };
+}
 function jsx(element, attributes, ...children) {
   if (typeof element === "string") {
     const { bind: bind2, immediateBind, childrenBind, childrenBindMode, events, styleBind, immediateStyleBind, classBind, immediateClassBind, ...otherAttributes } = attributes ?? {};
@@ -9661,22 +9667,11 @@ function jsx(element, attributes, ...children) {
     };
   }
   if (typeof element === "function") {
-    const { childrenBind, childrenBindMode, ...otherAttributes } = attributes ?? {};
-    if (element === Fragment) {
-      return {
-        type: "fragment",
-        attributes: otherAttributes,
-        children,
-        childrenBind,
-        childrenBindMode
-      };
-    } else if (element === Children) {
-      const { context: context2 } = otherAttributes;
-      return {
-        type: "children",
-        context: context2
-      };
+    if (element === Fragment || element === Children || element === Static) {
+      const func = element;
+      return func(attributes ?? {}, ...children);
     }
+    const { childrenBind, childrenBindMode, ...otherAttributes } = attributes ?? {};
     return {
       type: "component",
       component: element,
@@ -9912,8 +9907,8 @@ function bindFragmentChildren(nodeDescription, node, subscription, context2, doc
 function buildElement(description, document2 = globalThis.document) {
   const element = document2.createElement(description.element);
   for (const [key, value] of Object.entries(description.attributes)) {
-    if (key.startsWith("data-")) {
-      element.dataset[key.replace(/^data-/, "")] = value;
+    if (key.includes("-")) {
+      element.setAttribute(key, (value ?? "").toString());
     } else if (key === "class") {
       element.className = value;
     } else if (key === "for") {
@@ -9967,6 +9962,9 @@ function buildNode(description, container2, elementBinds, nodeBinds, document2 =
         nodeBinds.push([fragmentComment, description]);
       }
       return container2;
+    case "static":
+      container2.appendChild(description.element);
+      return container2;
   }
 }
 function buildTree(description, container2 = null, elementBinds = [], nodeBinds = [], document2 = globalThis.document) {
@@ -9976,6 +9974,12 @@ function buildTree(description, container2 = null, elementBinds = [], nodeBinds 
     if (hasAnyBinds(description)) {
       elementBinds.push([element, description]);
     }
+  } else if (!container2 && description.type === "static") {
+    return {
+      elementBinds,
+      nodeBinds,
+      container: description.element
+    };
   } else if (!container2) {
     container2 = document2.createDocumentFragment();
     buildNode(description, container2, elementBinds, nodeBinds, document2);
@@ -9985,7 +9989,7 @@ function buildTree(description, container2 = null, elementBinds = [], nodeBinds 
       container2 = nextNode;
     }
   }
-  if (description.type !== "children" && description.type !== "fragment") {
+  if (description.type !== "children" && description.type !== "fragment" && description.type !== "static") {
     for (const child of description.children) {
       if (typeof child === "string") {
         container2.appendChild(document2.createTextNode(child));
@@ -10250,6 +10254,103 @@ function run(container2, component, options, placeholder, document2 = globalThis
 
 // main.tsx
 var import_jquery = __toESM(require_jquery(), 1);
+
+// node_modules/lucide/dist/esm/createElement.js
+var createElement = (tag2, attrs, children = []) => {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", tag2);
+  Object.keys(attrs).forEach((name) => {
+    element.setAttribute(name, String(attrs[name]));
+  });
+  if (children.length) {
+    children.forEach((child) => {
+      const childElement = createElement(...child);
+      element.appendChild(childElement);
+    });
+  }
+  return element;
+};
+var createElement$1 = ([tag2, attrs, children]) => createElement(tag2, attrs, children);
+
+// node_modules/lucide/dist/esm/defaultAttributes.js
+var defaultAttributes = {
+  xmlns: "http://www.w3.org/2000/svg",
+  width: 24,
+  height: 24,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  "stroke-width": 2,
+  "stroke-linecap": "round",
+  "stroke-linejoin": "round"
+};
+
+// node_modules/lucide/dist/esm/icons/fast-forward.js
+var FastForward = [
+  "svg",
+  defaultAttributes,
+  [
+    ["polygon", { points: "13 19 22 12 13 5 13 19" }],
+    ["polygon", { points: "2 19 11 12 2 5 2 19" }]
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/github.js
+var Github = [
+  "svg",
+  defaultAttributes,
+  [
+    [
+      "path",
+      {
+        d: "M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"
+      }
+    ],
+    ["path", { d: "M9 18c-4.51 2-5-2-7-2" }]
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/pause.js
+var Pause = [
+  "svg",
+  defaultAttributes,
+  [
+    ["rect", { width: "4", height: "16", x: "6", y: "4" }],
+    ["rect", { width: "4", height: "16", x: "14", y: "4" }]
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/play.js
+var Play = ["svg", defaultAttributes, [["polygon", { points: "5 3 19 12 5 21 5 3" }]]];
+
+// node_modules/lucide/dist/esm/icons/plus.js
+var Plus = [
+  "svg",
+  defaultAttributes,
+  [
+    ["path", { d: "M5 12h14" }],
+    ["path", { d: "M12 5v14" }]
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/rewind.js
+var Rewind = [
+  "svg",
+  defaultAttributes,
+  [
+    ["polygon", { points: "11 19 2 12 11 5 11 19" }],
+    ["polygon", { points: "22 19 13 12 22 5 22 19" }]
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/skip-forward.js
+var SkipForward = [
+  "svg",
+  defaultAttributes,
+  [
+    ["polygon", { points: "5 4 15 12 5 20 5 4" }],
+    ["line", { x1: "19", x2: "19", y1: "5", y2: "19" }]
+  ]
+];
 
 // node_modules/rxjs-spy/esm/index.js
 var noop_ = function noop_2() {
@@ -14533,6 +14634,11 @@ var CompRadProgVm = class {
   }
 };
 
+// icon.tsx
+function Icon({ icon }) {
+  return /* @__PURE__ */ jsx(Static, { element: createElement$1(icon) });
+}
+
 // progress.tsx
 function Progress({ item }, { bindImmediateEffect, events }) {
   const { finish, pause, slowDown, speedUp, unpause } = events;
@@ -14557,7 +14663,7 @@ function Progress({ item }, { bindImmediateEffect, events }) {
       styleBind: { display: pauseDisplay },
       events: { click: pause }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-pause" }))
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Pause }))
   ), /* @__PURE__ */ jsx(
     "button",
     {
@@ -14567,7 +14673,7 @@ function Progress({ item }, { bindImmediateEffect, events }) {
       styleBind: { display: unpauseDisplay },
       events: { click: unpause }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { class: "fa fa-play" }))
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Play }))
   ), /* @__PURE__ */ jsx(
     "button",
     {
@@ -14576,7 +14682,7 @@ function Progress({ item }, { bindImmediateEffect, events }) {
       className: "button",
       events: { click: slowDown }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-backward" }))
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Rewind }))
   ), /* @__PURE__ */ jsx(
     "button",
     {
@@ -14585,7 +14691,7 @@ function Progress({ item }, { bindImmediateEffect, events }) {
       className: "button",
       events: { click: speedUp }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-forward" }))
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: FastForward }))
   ), /* @__PURE__ */ jsx(
     "button",
     {
@@ -14594,7 +14700,7 @@ function Progress({ item }, { bindImmediateEffect, events }) {
       className: "button",
       events: { click: finish }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-fast-forward" }))
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: SkipForward }))
   ))), /* @__PURE__ */ jsx("div", { className: "level-item" }, /* @__PURE__ */ jsx("div", null, /* @__PURE__ */ jsx("div", { className: "heading is-capitalized" }, "Item Progress"), /* @__PURE__ */ jsx(
     "div",
     {
@@ -14684,7 +14790,9 @@ function Main(_props, { bindImmediateEffect, events }) {
       role: "button",
       class: "navbar-burger",
       title: "menu",
-      bind: { ariaExpanded: menuIsActive },
+      bind: {
+        ariaExpanded: menuIsActive.pipe(map((a) => a.toString()))
+      },
       classBind: { "is-active": menuIsActive },
       events: { click: events.toggleMenu }
     },
@@ -14717,7 +14825,7 @@ function Main(_props, { bindImmediateEffect, events }) {
         class: "button is-primary is-inverted",
         href: "https://github.com/WorldMaker/compradprog/"
       },
-      /* @__PURE__ */ jsx("span", { class: "icon" }, /* @__PURE__ */ jsx("i", { class: "fa fa-github" })),
+      /* @__PURE__ */ jsx("span", { class: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Github })),
       /* @__PURE__ */ jsx("span", null, "Source")
     )))
   )))), /* @__PURE__ */ jsx("div", { class: "hero-body" }, /* @__PURE__ */ jsx("div", { class: "container has-text-centered" }, /* @__PURE__ */ jsx("p", { class: "title" }, "Composite Radial Progress Demo"), /* @__PURE__ */ jsx("p", { class: "subtitle" }, "Visualize complex multi-item progress with a combined radial")))), /* @__PURE__ */ jsx("section", { class: "section" }, /* @__PURE__ */ jsx("div", { className: "dashboard" }, /* @__PURE__ */ jsx("div", { className: "dial" }, /* @__PURE__ */ jsx(
@@ -14751,7 +14859,7 @@ function Main(_props, { bindImmediateEffect, events }) {
       className: "button",
       events: { click: addItem }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-plus" })),
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Plus })),
     /* @__PURE__ */ jsx("span", null, "Add Item")
   )), /* @__PURE__ */ jsx("div", { className: "level-right" }, /* @__PURE__ */ jsx("div", { className: "buttons has-addons" }, /* @__PURE__ */ jsx(
     "button",
@@ -14761,7 +14869,7 @@ function Main(_props, { bindImmediateEffect, events }) {
       title: "Pause All",
       events: { click: pauseAll }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-pause" })),
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Pause })),
     /* @__PURE__ */ jsx("span", null, "All")
   ), /* @__PURE__ */ jsx(
     "button",
@@ -14771,7 +14879,7 @@ function Main(_props, { bindImmediateEffect, events }) {
       title: "Resume All",
       events: { click: unpauseAll }
     },
-    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx("span", { className: "fa fa-play" })),
+    /* @__PURE__ */ jsx("span", { className: "icon" }, /* @__PURE__ */ jsx(Icon, { icon: Play })),
     /* @__PURE__ */ jsx("span", null, "All")
   ))))), /* @__PURE__ */ jsx(
     "div",
@@ -14799,6 +14907,86 @@ jquery/dist/jquery.js:
    * https://jquery.org/license
    *
    * Date: 2021-03-02T17:08Z
+   *)
+
+lucide/dist/esm/createElement.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/defaultAttributes.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/fast-forward.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/github.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/pause.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/play.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/plus.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/rewind.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/icons/skip-forward.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+
+lucide/dist/esm/lucide.js:
+  (**
+   * @license lucide v0.307.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
    *)
 
 rxjs-spy/esm/index.js:

--- a/main.tsx
+++ b/main.tsx
@@ -6,6 +6,7 @@ import {
   run,
 } from 'butterfloat'
 import $ from 'jquery'
+import { Github, Pause, Play, Plus } from 'lucide'
 import {
   Observable,
   filter,
@@ -19,6 +20,7 @@ import {
 import { create } from 'rxjs-spy'
 import { tag } from 'rxjs-spy/operators'
 import { CompRadProgVm } from './compradprogvm'
+import { Icon } from './icon'
 import { Progress } from './progress'
 
 const spy = create()
@@ -120,7 +122,9 @@ function Main(
                   role="button"
                   class="navbar-burger"
                   title="menu"
-                  bind={{ ariaExpanded: menuIsActive }}
+                  bind={{
+                    ariaExpanded: menuIsActive.pipe(map((a) => a.toString())),
+                  }}
                   classBind={{ 'is-active': menuIsActive }}
                   events={{ click: events.toggleMenu }}
                 >
@@ -152,7 +156,7 @@ function Main(
                       href="https://github.com/WorldMaker/compradprog/"
                     >
                       <span class="icon">
-                        <i class="fa fa-github"></i>
+                        <Icon icon={Github} />
                       </span>
                       <span>Source</span>
                     </a>
@@ -217,7 +221,7 @@ function Main(
                   events={{ click: addItem }}
                 >
                   <span className="icon">
-                    <span className="fa fa-plus"></span>
+                    <Icon icon={Plus} />
                   </span>
                   <span>Add Item</span>
                 </button>
@@ -231,7 +235,7 @@ function Main(
                     events={{ click: pauseAll }}
                   >
                     <span className="icon">
-                      <span className="fa fa-pause"></span>
+                      <Icon icon={Pause} />
                     </span>
                     <span>All</span>
                   </button>
@@ -242,7 +246,7 @@ function Main(
                     events={{ click: unpauseAll }}
                   >
                     <span className="icon">
-                      <span className="fa fa-play"></span>
+                      <Icon icon={Play} />
                     </span>
                     <span>All</span>
                   </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.9.3",
-        "butterfloat": "^1.1.0",
+        "butterfloat": "^1.3.0",
         "jquery": "^3.6.0",
         "jquery-knob": "^1.2.11",
+        "lucide": "^0.307.0",
         "rxjs": "^7.8.1",
         "rxjs-spy": "^8.0.2"
       },
@@ -809,9 +810,9 @@
       }
     },
     "node_modules/butterfloat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/butterfloat/-/butterfloat-1.1.0.tgz",
-      "integrity": "sha512-WFNxfMjuMdkOpGVyoRATP/B/ol4XHwYWGZN4sZxzqmnWQSJt7azWq1m90PKslCvNvsgsoTCJznGDD67pq2g+rQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/butterfloat/-/butterfloat-1.3.0.tgz",
+      "integrity": "sha512-rL2lqvh9HiAePv3TgpieP7K0OJ4qVy2wlZgxbTeO6S5pDDloYOjZm3vGdU6dgCgva1XamWF6WveCwgS6qdsBDA==",
       "dependencies": {
         "rxjs": "^7.8.1"
       }
@@ -1210,6 +1211,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lucide": {
+      "version": "0.307.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.307.0.tgz",
+      "integrity": "sha512-sXtheSpSq18mO63jgqwBDJS0ZwKM00baFGjm1EgYEzFHJyfmaKuyqzpqgZt2cg0SEk708WhheDjvAH5V6E5VHg=="
     },
     "node_modules/mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "type": "module",
   "dependencies": {
     "@types/node": "^20.9.3",
-    "butterfloat": "^1.1.0",
+    "butterfloat": "^1.3.0",
     "jquery": "^3.6.0",
     "jquery-knob": "^1.2.11",
+    "lucide": "^0.307.0",
     "rxjs": "^7.8.1",
     "rxjs-spy": "^8.0.2"
   },

--- a/progress.tsx
+++ b/progress.tsx
@@ -1,5 +1,7 @@
 import { ComponentContext, ObservableEvent, jsx } from 'butterfloat'
+import { FastForward, Pause, Play, Rewind, SkipForward, StepBack } from 'lucide'
 import { map } from 'rxjs'
+import { Icon } from './icon'
 import { ProgVm } from './progvm'
 
 export interface ProgressProps {
@@ -49,7 +51,7 @@ export function Progress(
               events={{ click: pause }}
             >
               <span className="icon">
-                <span className="fa fa-pause"></span>
+                <Icon icon={Pause} />
               </span>
             </button>
             <button
@@ -60,7 +62,7 @@ export function Progress(
               events={{ click: unpause }}
             >
               <span className="icon">
-                <span class="fa fa-play"></span>
+                <Icon icon={Play} />
               </span>
             </button>
             <button
@@ -70,7 +72,7 @@ export function Progress(
               events={{ click: slowDown }}
             >
               <span className="icon">
-                <span className="fa fa-backward"></span>
+                <Icon icon={Rewind} />
               </span>
             </button>
             <button
@@ -80,7 +82,7 @@ export function Progress(
               events={{ click: speedUp }}
             >
               <span className="icon">
-                <span className="fa fa-forward"></span>
+                <Icon icon={FastForward} />
               </span>
             </button>
             <button
@@ -90,7 +92,7 @@ export function Progress(
               events={{ click: finish }}
             >
               <span className="icon">
-                <span className="fa fa-fast-forward"></span>
+                <Icon icon={SkipForward} />
               </span>
             </button>
           </div>


### PR DESCRIPTION
Lucide icons look more modern like FA5/FA6 and include ESM-based treeshaking for SVG icons like those, but has a much simpler licensing model.